### PR TITLE
Check for type in $gt, $lt, etc. and fix tests for $lte

### DIFF
--- a/ops.js
+++ b/ops.js
@@ -19,7 +19,7 @@ exports.$ne = function $ne(matcher, val){
  */
 
 exports.$gt = function $gt(matcher, val){
-  return val > matcher;
+  return type(matcher) === 'number' && val > matcher;
 };
 
 /**
@@ -27,7 +27,7 @@ exports.$gt = function $gt(matcher, val){
  */
 
 exports.$gte = function $gte(matcher, val){
-  return val >= matcher;
+  return type(matcher) === 'number' && val >= matcher;
 };
 
 /**
@@ -35,7 +35,7 @@ exports.$gte = function $gte(matcher, val){
  */
 
 exports.$lt = function $lt(matcher, val){
-  return val < matcher;
+  return type(matcher) === 'number' && val < matcher;
 };
 
 /**
@@ -43,7 +43,7 @@ exports.$lt = function $lt(matcher, val){
  */
 
 exports.$lte = function $lte(matcher, val){
-  return val <= matcher;
+  return type(matcher) === 'number' && val <= matcher;
 };
 
 /**

--- a/test/filter.js
+++ b/test/filter.js
@@ -24,22 +24,26 @@ describe('filter', function(){
     it('gt', function(){
       expect(ops.$gt(4, 5)).to.be(true);
       expect(ops.$gt(4, 4)).to.be(false);
+      expect(ops.$gt(false, 4)).to.be(false);
     });
 
     it('gte', function(){
       expect(ops.$gte(4, 5)).to.be(true);
       expect(ops.$gte(4, 4)).to.be(true);
       expect(ops.$gte(5, 4)).to.be(false);
+      expect(ops.$gte(false, 4)).to.be(false);
     });
 
     it('lt', function(){
       expect(ops.$gt(4, 5)).to.be(true);
       expect(ops.$gt(4, 4)).to.be(false);
+      expect(ops.$gt(false, 4)).to.be(false);
     });
 
     it('lte', function(){
-      expect(ops.$gt(4, 5)).to.be(true);
-      expect(ops.$gt(4, 4)).to.be(false);
+      expect(ops.$lte(4, 5)).to.be(false);
+      expect(ops.$lte(4, 4)).to.be(true);
+      expect(ops.$lte(false, 4)).to.be(false);
     });
 
     it('exists', function(){


### PR DESCRIPTION
This library is super awesome, but a couple simple improvements for more mongodb-inspired goodness:

1) $gt, $lt, $gte, and $lte should return false if the underlying matcher isn't a number
2) The $lte tests were actually testing $gt
